### PR TITLE
New: add new ImagePost FeedItem model

### DIFF
--- a/tiktokpy/models/feed.py
+++ b/tiktokpy/models/feed.py
@@ -134,7 +134,7 @@ class FeedItem(BaseModel):
         fields: ClassVar[dict] = {
             "create_time": "createTime",
             "image_post": "imagePost",
-    }
+        }
 
 
 class FeedItems(BaseModel):

--- a/tiktokpy/models/feed.py
+++ b/tiktokpy/models/feed.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, List
+from typing import ClassVar, List, Optional
 
 from pydantic import BaseModel, HttpUrl
 
@@ -80,8 +80,8 @@ class VideoInfo(BaseModel):
     duration: int
     ratio: str
     cover: HttpUrl
-    play_addr: HttpUrl
-    download_addr: HttpUrl
+    play_addr: Optional[HttpUrl]
+    download_addr: Optional[HttpUrl]
 
     class Config:
         fields: ClassVar[dict] = {
@@ -93,6 +93,18 @@ class VideoInfo(BaseModel):
     def original_video_url(self) -> str:
         return f"https://api2.musical.ly/aweme/v1/playwm/?video_id={self.id}"
 
+class ImageUrls(BaseModel):
+    urlList: List[HttpUrl]
+
+class ImageInfo(BaseModel):
+    imageHeight: int
+    imageWidth: int
+    imageURL: ImageUrls
+
+class ImagePostlInfo(BaseModel):
+    cover: ImageInfo
+    images: List[ImageInfo]
+    shareCover: ImageInfo
 
 class FeedItem(BaseModel):
     id: str
@@ -102,6 +114,7 @@ class FeedItem(BaseModel):
     music: MusicInfo
     stats: StatisticsInfo
     video: VideoInfo
+    imagePost: ImagePostlInfo = None
     challenges: List[ChallengeInfo] = []
 
     class Config:

--- a/tiktokpy/models/feed.py
+++ b/tiktokpy/models/feed.py
@@ -131,7 +131,10 @@ class FeedItem(BaseModel):
     challenges: List[ChallengeInfo] = []
 
     class Config:
-        fields: ClassVar[dict] = {"create_time": "createTime", "image_post": "imagePost"}
+        fields: ClassVar[dict] = {
+            "create_time": "createTime",
+            "image_post": "imagePost",
+    }
 
 
 class FeedItems(BaseModel):

--- a/tiktokpy/models/feed.py
+++ b/tiktokpy/models/feed.py
@@ -117,11 +117,9 @@ class ImageInfo(BaseModel):
         }
 
 
-
 class ImagePostlInfo(BaseModel):
     cover: ImageInfo
     images: List[ImageInfo]
-
 
 
 class FeedItem(BaseModel):
@@ -132,7 +130,7 @@ class FeedItem(BaseModel):
     music: MusicInfo
     stats: StatisticsInfo
     video: VideoInfo
-    imagePost: ImagePostlInfo = None
+    image_post: ImagePostlInfo = None
     challenges: List[ChallengeInfo] = []
 
     class Config:

--- a/tiktokpy/models/feed.py
+++ b/tiktokpy/models/feed.py
@@ -98,10 +98,7 @@ class ImageUrls(BaseModel):
     url_list: List[HttpUrl]
 
     class Config:
-        fields: ClassVar[dict] = {
-            "url_list": "urlList"            
-        }
-
+        fields: ClassVar[dict] = {"url_list": "urlList"}
 
 
 class ImageInfo(BaseModel):
@@ -111,9 +108,9 @@ class ImageInfo(BaseModel):
 
     class Config:
         fields: ClassVar[dict] = {
-            "image_url": "imageURL",   
+            "image_url": "imageURL",
             "image_width": "imageWidth",
-            "image_height": "imageHeight"            
+            "image_height": "imageHeight",
         }
 
 
@@ -134,10 +131,7 @@ class FeedItem(BaseModel):
     challenges: List[ChallengeInfo] = []
 
     class Config:
-        fields: ClassVar[dict] = {
-            "create_time": "createTime",
-            "image_post": "imagePost"
-        }
+        fields: ClassVar[dict] = {"create_time": "createTime", "image_post": "imagePost"}
 
 
 class FeedItems(BaseModel):

--- a/tiktokpy/models/feed.py
+++ b/tiktokpy/models/feed.py
@@ -95,19 +95,33 @@ class VideoInfo(BaseModel):
 
 
 class ImageUrls(BaseModel):
-    urlList: List[HttpUrl]
+    url_list: List[HttpUrl]
+
+    class Config:
+        fields: ClassVar[dict] = {
+            "url_list": "urlList"            
+        }
+
 
 
 class ImageInfo(BaseModel):
-    imageHeight: int
-    imageWidth: int
-    imageURL: ImageUrls
+    image_height: int
+    image_width: int
+    image_url: ImageUrls
+
+    class Config:
+        fields: ClassVar[dict] = {
+            "image_url": "imageURL",   
+            "image_width": "imageWidth",
+            "image_height": "imageHeight"            
+        }
+
 
 
 class ImagePostlInfo(BaseModel):
     cover: ImageInfo
     images: List[ImageInfo]
-    shareCover: ImageInfo
+
 
 
 class FeedItem(BaseModel):
@@ -124,6 +138,7 @@ class FeedItem(BaseModel):
     class Config:
         fields: ClassVar[dict] = {
             "create_time": "createTime",
+            "image_post": "imagePost"
         }
 
 

--- a/tiktokpy/models/feed.py
+++ b/tiktokpy/models/feed.py
@@ -93,18 +93,22 @@ class VideoInfo(BaseModel):
     def original_video_url(self) -> str:
         return f"https://api2.musical.ly/aweme/v1/playwm/?video_id={self.id}"
 
+
 class ImageUrls(BaseModel):
     urlList: List[HttpUrl]
+
 
 class ImageInfo(BaseModel):
     imageHeight: int
     imageWidth: int
     imageURL: ImageUrls
 
+
 class ImagePostlInfo(BaseModel):
     cover: ImageInfo
     images: List[ImageInfo]
     shareCover: ImageInfo
+
 
 class FeedItem(BaseModel):
     id: str


### PR DESCRIPTION
I was testing this code and looked promising. The model did not implement ImagePost as a FeedItem, I included the basic classes so that both videos and imagePosts can be successfully handled by the model.

I have not dived in at all, the changes are basically:

Added a new property to the existing FeedItem class, when the item is a regular video, you do not receive the new property, so it is initialized to None.
```
class FeedItem(BaseModel):
    id: str
    ...
    video: VideoInfo
+    image_post: ImagePostlInfo = None
    challenges: List[ChallengeInfo] = []
```

When the item is ImagePost, it still has video property, but two required properties will be missing, so I made them Optional in the VideoInfo definition:

```
class VideoInfo(BaseModel):
    id: str
    ...
    cover: HttpUrl
-  play_addr: HttpUrl
-  download_addr: HttpUrl
+  play_addr: Optional[HttpUrl]
+  download_addr: Optional[HttpUrl]
```

Lastly I realized that in the new imagePost data, properties with 'image type' values had a consistent structure (imagePost cover, shareCover and images). So I added imagePostInfo model and a new class for these properties:

```
+ class ImageUrls(BaseModel):
+     url_list: List[HttpUrl]
+ 
+     class Config:
+         fields: ClassVar[dict] = {"url_list": "urlList"}
+ 
+ 
+ class ImageInfo(BaseModel):
+     image_height: int
+     image_width: int
+     image_url: ImageUrls
+ 
+     class Config:
+         fields: ClassVar[dict] = {
+             "image_url": "imageURL",
+             "image_width": "imageWidth",
+             "image_height": "imageHeight",
+         }
+ 
+ 
+ class ImagePostlInfo(BaseModel):
+     cover: ImageInfo
+     images: List[ImageInfo]
```